### PR TITLE
Add GHCR publish workflow with manual version input

### DIFF
--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,0 +1,84 @@
+name: Publish Docker image to GHCR
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Optional image version tag (example: 1.2.3)"
+        required: false
+        type: string
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/yodaspeak
+
+permissions:
+  contents: read
+  packages: write
+  attestations: write
+  id-token: write
+  artifact-metadata: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize image name
+        id: image
+        run: echo "name=$(echo '${{ env.IMAGE_NAME }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Extract image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=tag
+            type=sha
+
+      - name: Build tag list (manual version + metadata tags)
+        id: tags
+        run: |
+          {
+            echo "list<<EOF"
+            echo "${{ steps.meta.outputs.tags }}"
+            if [ -n "${{ github.event.inputs.version }}" ]; then
+              echo "${{ env.REGISTRY }}/${{ steps.image.outputs.name }}:${{ github.event.inputs.version }}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.list }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Generate artifact attestation
+        uses: actions/attest@v4
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ steps.image.outputs.name }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -6,9 +6,6 @@ on:
       - main
     tags:
       - "v*"
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -6,6 +6,9 @@ on:
       - main
     tags:
       - "v*"
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version:

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Small Django demo app that translates plain English into a Yoda-style response.
 docker compose up --build
 ```
 
+The app image is configured as `ghcr.io/ryanblunden/yodaspeak:latest`.
+The GitHub Actions workflow at `.github/workflows/publish-ghcr.yml` publishes that image to GHCR on pushes to `main` and on version tags like `v1.0.0`.
+
 The app is served on port `8000` by default. The default `.env` uses SQLite and does not require Redis. To exercise the multi-container path, switch `DATABASE_ENGINE=POSTGRES` and `CACHE_ENABLED=true`.
 
 ## Environment variables

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 services:
   app:
     container_name: app
-    image: ryanblunden/yodaspeak
+    image: ghcr.io/ryanblunden/yodaspeak:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- add GHCR publish workflow
- update compose image path to GHCR
- add workflow_dispatch version input for explicit image tags

## Notes
- local act dry-run fails schema validation on newer artifact-metadata permission key (act schema lag), so validation should be done in GitHub Actions on this PR branch

## Test plan
- run workflow manually from this branch with version=0.0.0-test
- verify image tags are pushed to GHCR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include Docker image deployment and configuration information, as well as details about how the application's container image is published and maintained.

* **Chores**
  * Updated Docker image configuration to use a new container registry, with built-in support for automated version tagging and release management across all deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryan-blunden/yodaspeak/pull/2?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->